### PR TITLE
Modernization-metadata for absint-a3

### DIFF
--- a/absint-a3/modernization-metadata/2025-09-02T14-13-06.json
+++ b/absint-a3/modernization-metadata/2025-09-02T14-13-06.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "absint-a3",
+  "pluginRepository": "https://github.com/jenkinsci/absint-a3-plugin.git",
+  "pluginVersion": "1.1.0",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.462",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Upgrade to latest LTS core version supporting Java 11",
+  "migrationDescription": "Upgrade to latest LTS core version supporting Java 11.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/absint-a3-plugin/pull/11",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 15,
+  "deletions": 18,
+  "changedFiles": 1,
+  "key": "2025-09-02T14-13-06.json",
+  "path": "metadata-plugin-modernizer/absint-a3/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `absint-a3` at `2025-09-02T14:13:09.334765736Z[UTC]`
PR: https://github.com/jenkinsci/absint-a3-plugin/pull/11