### PR TITLE
Modernization-metadata for probely-security

### DIFF
--- a/probely-security/modernization-metadata/2025-09-02T15-43-31.json
+++ b/probely-security/modernization-metadata/2025-09-02T15-43-31.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "probely-security",
+  "pluginRepository": "https://github.com/jenkinsci/probely-security-plugin.git",
+  "pluginVersion": "1.2.3",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.479",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Add CODEOWNERS file",
+  "migrationDescription": "Adds a CODEOWNERS file to a Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.AddCodeOwner",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/probely-security-plugin/pull/12",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-09-02T15-43-31.json",
+  "path": "metadata-plugin-modernizer/probely-security/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `probely-security` at `2025-09-02T15:43:33.971480839Z[UTC]`
PR: https://github.com/jenkinsci/probely-security-plugin/pull/12