### PR TITLE
Modernization-metadata for compuware-strobe-measurement

### DIFF
--- a/compuware-strobe-measurement/modernization-metadata/2025-09-03T10-49-17.json
+++ b/compuware-strobe-measurement/modernization-metadata/2025-09-03T10-49-17.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "compuware-strobe-measurement",
+  "pluginRepository": "https://github.com/jenkinsci/compuware-strobe-measurement-plugin.git",
+  "pluginVersion": "1.0.4",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.176",
+  "effectiveBaseline": "2.176",
+  "jenkinsVersion": "2.176",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/compuware-strobe-measurement-plugin/pull/17",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-09-03T10-49-17.json",
+  "path": "metadata-plugin-modernizer/compuware-strobe-measurement/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `compuware-strobe-measurement` at `2025-09-03T10:49:18.991547212Z[UTC]`
PR: https://github.com/jenkinsci/compuware-strobe-measurement-plugin/pull/17