### PR TITLE
Modernization-metadata for compuware-xpediter-code-coverage

### DIFF
--- a/compuware-xpediter-code-coverage/modernization-metadata/2025-09-03T10-59-47.json
+++ b/compuware-xpediter-code-coverage/modernization-metadata/2025-09-03T10-59-47.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "compuware-xpediter-code-coverage",
+  "pluginRepository": "https://github.com/jenkinsci/compuware-xpediter-code-coverage-plugin.git",
+  "pluginVersion": "1.1.0",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.222",
+  "effectiveBaseline": "2.222",
+  "jenkinsVersion": "2.222.4",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/compuware-xpediter-code-coverage-plugin/pull/23",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-09-03T10-59-47.json",
+  "path": "metadata-plugin-modernizer/compuware-xpediter-code-coverage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `compuware-xpediter-code-coverage` at `2025-09-03T10:59:49.538151464Z[UTC]`
PR: https://github.com/jenkinsci/compuware-xpediter-code-coverage-plugin/pull/23