### PR TITLE
Modernization-metadata for dos-trigger

### DIFF
--- a/dos-trigger/modernization-metadata/2025-09-03T12-09-21.json
+++ b/dos-trigger/modernization-metadata/2025-09-03T12-09-21.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "dos-trigger",
+  "pluginRepository": "https://github.com/jenkinsci/dos-trigger-plugin.git",
+  "pluginVersion": "1.23",
+  "jenkinsBaseline": "",
+  "targetBaseline": "1.625",
+  "effectiveBaseline": "1.625",
+  "jenkinsVersion": "1.625.3",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "fail",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2025-09-03T12-09-21.json",
+  "path": "metadata-plugin-modernizer/dos-trigger/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `dos-trigger` at `2025-09-03T12:09:23.493446966Z[UTC]`
PR: null