### PR TITLE
Modernization-metadata for regression-report-plugin

### DIFF
--- a/regression-report-plugin/modernization-metadata/2025-09-04T08-49-32.json
+++ b/regression-report-plugin/modernization-metadata/2025-09-04T08-49-32.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "regression-report-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/regression-report-plugin.git",
+  "pluginVersion": "1.5",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.249",
+  "effectiveBaseline": "2.249",
+  "jenkinsVersion": "2.249",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/regression-report-plugin/pull/16",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-09-04T08-49-32.json",
+  "path": "metadata-plugin-modernizer/regression-report-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `regression-report-plugin` at `2025-09-04T08:49:34.113386973Z[UTC]`
PR: https://github.com/jenkinsci/regression-report-plugin/pull/16