### PR TITLE
Modernization-metadata for vectorcast-execution

### DIFF
--- a/vectorcast-execution/modernization-metadata/2025-09-04T11-21-22.json
+++ b/vectorcast-execution/modernization-metadata/2025-09-04T11-21-22.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "vectorcast-execution",
+  "pluginRepository": "https://github.com/jenkinsci/vectorcast-execution-plugin.git",
+  "pluginVersion": "0.78",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.462",
+  "effectiveBaseline": "2.462",
+  "jenkinsVersion": "2.462.3",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/123",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-09-04T11-21-22.json",
+  "path": "metadata-plugin-modernizer/vectorcast-execution/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `vectorcast-execution` at `2025-09-04T11:21:24.254287926Z[UTC]`
PR: https://github.com/jenkinsci/vectorcast-execution-plugin/pull/123