### PR TITLE
Modernization-metadata for pipeline-groovy-lib

### DIFF
--- a/pipeline-groovy-lib/modernization-metadata/2025-09-09T17-26-13.json
+++ b/pipeline-groovy-lib/modernization-metadata/2025-09-09T17-26-13.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "pipeline-groovy-lib",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-groovy-lib-plugin.git",
+  "pluginVersion": "752.vdddedf804e72",
+  "jenkinsBaseline": "2.504",
+  "targetBaseline": "2.504",
+  "effectiveBaseline": "2.504",
+  "jenkinsVersion": "2.504.1",
+  "migrationName": "Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text",
+  "migrationDescription": "Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/195",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 7,
+  "deletions": 3,
+  "changedFiles": 4,
+  "key": "2025-09-09T17-26-13.json",
+  "path": "metadata-plugin-modernizer/pipeline-groovy-lib/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-groovy-lib` at `2025-09-09T17:26:15.341972362Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/195