### PR TITLE
Modernization-metadata for command-launcher

### DIFF
--- a/command-launcher/modernization-metadata/2025-09-09T17-38-33.json
+++ b/command-launcher/modernization-metadata/2025-09-09T17-38-33.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "command-launcher",
+  "pluginRepository": "https://github.com/jenkinsci/command-launcher-plugin.git",
+  "pluginVersion": "123.v37cfdc92ef67",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.479",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text",
+  "migrationDescription": "Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/command-launcher-plugin/pull/118",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 6,
+  "deletions": 2,
+  "changedFiles": 3,
+  "key": "2025-09-09T17-38-33.json",
+  "path": "metadata-plugin-modernizer/command-launcher/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `command-launcher` at `2025-09-09T17:38:35.412636240Z[UTC]`
PR: https://github.com/jenkinsci/command-launcher-plugin/pull/118