### PR TITLE
Modernization-metadata for bitbucket-kubernetes-credentials

### DIFF
--- a/bitbucket-kubernetes-credentials/modernization-metadata/2026-04-18T09-29-10.json
+++ b/bitbucket-kubernetes-credentials/modernization-metadata/2026-04-18T09-29-10.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "bitbucket-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin.git",
+  "pluginVersion": "613.v124fea_1166d5",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/356",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T09-29-10.json",
+  "path": "metadata-plugin-modernizer/bitbucket-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-kubernetes-credentials` at `2026-04-18T09:29:14.526673964Z[UTC]`
PR: https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/356