### PR TITLE
Modernization-metadata for build-history-metrics-plugin

### DIFF
--- a/build-history-metrics-plugin/modernization-metadata/2026-04-18T09-31-17.json
+++ b/build-history-metrics-plugin/modernization-metadata/2026-04-18T09-31-17.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "build-history-metrics-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/build-history-metrics-plugin.git",
+  "pluginVersion": "183.vb_9c822e0943e",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/103",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T09-31-17.json",
+  "path": "metadata-plugin-modernizer/build-history-metrics-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `build-history-metrics-plugin` at `2026-04-18T09:31:21.095014545Z[UTC]`
PR: https://github.com/jenkinsci/build-history-metrics-plugin/pull/103