### PR TITLE
Modernization-metadata for exclusive-label-plugin

### DIFF
--- a/exclusive-label-plugin/modernization-metadata/2026-04-18T09-37-26.json
+++ b/exclusive-label-plugin/modernization-metadata/2026-04-18T09-37-26.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "exclusive-label-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/exclusive-labels-plugin.git",
+  "pluginVersion": "19.v40532946d413",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/exclusive-labels-plugin/pull/22",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T09-37-26.json",
+  "path": "metadata-plugin-modernizer/exclusive-label-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `exclusive-label-plugin` at `2026-04-18T09:37:29.735717942Z[UTC]`
PR: https://github.com/jenkinsci/exclusive-labels-plugin/pull/22