### PR TITLE
Modernization-metadata for gitlab-kubernetes-credentials

### DIFF
--- a/gitlab-kubernetes-credentials/modernization-metadata/2026-04-18T09-51-31.json
+++ b/gitlab-kubernetes-credentials/modernization-metadata/2026-04-18T09-51-31.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "gitlab-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin.git",
+  "pluginVersion": "538.v99cc6503c421",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/306",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T09-51-31.json",
+  "path": "metadata-plugin-modernizer/gitlab-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gitlab-kubernetes-credentials` at `2026-04-18T09:51:34.838485406Z[UTC]`
PR: https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/306