### PR TITLE
Modernization-metadata for jcaptcha-plugin

### DIFF
--- a/jcaptcha-plugin/modernization-metadata/2026-04-18T09-57-27.json
+++ b/jcaptcha-plugin/modernization-metadata/2026-04-18T09-57-27.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jcaptcha-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/jcaptcha-plugin.git",
+  "pluginVersion": "66.vf5a_222f99e7b_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jcaptcha-plugin/pull/57",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T09-57-27.json",
+  "path": "metadata-plugin-modernizer/jcaptcha-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jcaptcha-plugin` at `2026-04-18T09:57:30.578772364Z[UTC]`
PR: https://github.com/jenkinsci/jcaptcha-plugin/pull/57