### PR TITLE
Modernization-metadata for parameter-separator

### DIFF
--- a/parameter-separator/modernization-metadata/2026-04-18T10-20-41.json
+++ b/parameter-separator/modernization-metadata/2026-04-18T10-20-41.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "parameter-separator",
+  "pluginRepository": "https://github.com/jenkinsci/parameter-separator-plugin.git",
+  "pluginVersion": "334.v1fc0e534c71d",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/parameter-separator-plugin/pull/162",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T10-20-41.json",
+  "path": "metadata-plugin-modernizer/parameter-separator/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `parameter-separator` at `2026-04-18T10:20:44.652007276Z[UTC]`
PR: https://github.com/jenkinsci/parameter-separator-plugin/pull/162