### PR TITLE
Modernization-metadata for pipeline-cps-http

### DIFF
--- a/pipeline-cps-http/modernization-metadata/2026-04-18T10-23-11.json
+++ b/pipeline-cps-http/modernization-metadata/2026-04-18T10-23-11.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "pipeline-cps-http",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-cps-http-plugin.git",
+  "pluginVersion": "201.v59370c7cf0ec",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/84",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T10-23-11.json",
+  "path": "metadata-plugin-modernizer/pipeline-cps-http/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-cps-http` at `2026-04-18T10:23:14.563731446Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/84