### PR TITLE
Modernization-metadata for webhook-secret-credentials-provider

### DIFF
--- a/webhook-secret-credentials-provider/modernization-metadata/2026-04-18T10-46-01.json
+++ b/webhook-secret-credentials-provider/modernization-metadata/2026-04-18T10-46-01.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "webhook-secret-credentials-provider",
+  "pluginRepository": "https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin.git",
+  "pluginVersion": "16.v0cfa_f0215cf5",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin/pull/19",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-04-18T10-46-01.json",
+  "path": "metadata-plugin-modernizer/webhook-secret-credentials-provider/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `webhook-secret-credentials-provider` at `2026-04-18T10:46:04.681145943Z[UTC]`
PR: https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin/pull/19