### PR TITLE
Modernization-metadata for bitbucket-kubernetes-credentials

### DIFF
--- a/bitbucket-kubernetes-credentials/modernization-metadata/2026-04-25T16-50-23.json
+++ b/bitbucket-kubernetes-credentials/modernization-metadata/2026-04-25T16-50-23.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "bitbucket-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin.git",
+  "pluginVersion": "613.v124fea_1166d5",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Remove Release Drafter if CD is enabled",
+  "migrationDescription": "Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/361",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2026-04-25T16-50-23.json",
+  "path": "metadata-plugin-modernizer/bitbucket-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-kubernetes-credentials` at `2026-04-25T16:50:27.061677772Z[UTC]`
PR: https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/361