### PR TITLE
Modernization-metadata for joda-time-api

### DIFF
--- a/joda-time-api/modernization-metadata/2026-05-23T15-56-33.json
+++ b/joda-time-api/modernization-metadata/2026-05-23T15-56-33.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "joda-time-api",
+  "pluginRepository": "https://github.com/jenkinsci/joda-time-api-plugin.git",
+  "pluginVersion": "2.14.2-193.v422b_efce56e0",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/joda-time-api-plugin/pull/105",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T15-56-33.json",
+  "path": "metadata-plugin-modernizer/joda-time-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `joda-time-api` at `2026-05-23T15:56:37.673259728Z[UTC]`
PR: https://github.com/jenkinsci/joda-time-api-plugin/pull/105