### PR TITLE
Modernization-metadata for bitbucket-kubernetes-credentials

### DIFF
--- a/bitbucket-kubernetes-credentials/modernization-metadata/2026-05-23T16-10-58.json
+++ b/bitbucket-kubernetes-credentials/modernization-metadata/2026-05-23T16-10-58.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "bitbucket-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin.git",
+  "pluginVersion": "662.v96d8b_a_90e07e",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/362",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T16-10-58.json",
+  "path": "metadata-plugin-modernizer/bitbucket-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-kubernetes-credentials` at `2026-05-23T16:11:01.341643362Z[UTC]`
PR: https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/362