### PR TITLE
Modernization-metadata for build-history-metrics-plugin

### DIFF
--- a/build-history-metrics-plugin/modernization-metadata/2026-05-23T16-13-07.json
+++ b/build-history-metrics-plugin/modernization-metadata/2026-05-23T16-13-07.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "build-history-metrics-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/build-history-metrics-plugin.git",
+  "pluginVersion": "217.vf34ff6a_b_41ca_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/109",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T16-13-07.json",
+  "path": "metadata-plugin-modernizer/build-history-metrics-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `build-history-metrics-plugin` at `2026-05-23T16:13:10.850496620Z[UTC]`
PR: https://github.com/jenkinsci/build-history-metrics-plugin/pull/109