### PR TITLE
Modernization-metadata for coverage-badges-extension

### DIFF
--- a/coverage-badges-extension/modernization-metadata/2026-05-23T16-15-17.json
+++ b/coverage-badges-extension/modernization-metadata/2026-05-23T16-15-17.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "coverage-badges-extension",
+  "pluginRepository": "https://github.com/jenkinsci/coverage-badges-extension-plugin.git",
+  "pluginVersion": "234.v43c3ef3878b_c",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/137",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T16-15-17.json",
+  "path": "metadata-plugin-modernizer/coverage-badges-extension/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `coverage-badges-extension` at `2026-05-23T16:15:20.795212207Z[UTC]`
PR: https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/137