### PR TITLE
Modernization-metadata for extended-read-permission

### DIFF
--- a/extended-read-permission/modernization-metadata/2026-05-23T16-24-16.json
+++ b/extended-read-permission/modernization-metadata/2026-05-23T16-24-16.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "extended-read-permission",
+  "pluginRepository": "https://github.com/jenkinsci/extended-read-permission-plugin.git",
+  "pluginVersion": "68.vd270568a_7520",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/extended-read-permission-plugin/pull/60",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T16-24-16.json",
+  "path": "metadata-plugin-modernizer/extended-read-permission/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `extended-read-permission` at `2026-05-23T16:24:20.238292050Z[UTC]`
PR: https://github.com/jenkinsci/extended-read-permission-plugin/pull/60