### PR TITLE
Modernization-metadata for jcaptcha-plugin

### DIFF
--- a/jcaptcha-plugin/modernization-metadata/2026-05-23T16-37-50.json
+++ b/jcaptcha-plugin/modernization-metadata/2026-05-23T16-37-50.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jcaptcha-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/jcaptcha-plugin.git",
+  "pluginVersion": "108.v49e0795497c2",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jcaptcha-plugin/pull/62",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-05-23T16-37-50.json",
+  "path": "metadata-plugin-modernizer/jcaptcha-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jcaptcha-plugin` at `2026-05-23T16:37:54.011896513Z[UTC]`
PR: https://github.com/jenkinsci/jcaptcha-plugin/pull/62