### PR TITLE
Modernization-metadata for byte-buddy-api

### DIFF
--- a/byte-buddy-api/modernization-metadata/2026-06-06T15-40-26.json
+++ b/byte-buddy-api/modernization-metadata/2026-06-06T15-40-26.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "byte-buddy-api",
+  "pluginRepository": "https://github.com/jenkinsci/byte-buddy-api-plugin.git",
+  "pluginVersion": "1.18.9-239.v86a_51b_b_43123",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/130",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T15-40-26.json",
+  "path": "metadata-plugin-modernizer/byte-buddy-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `byte-buddy-api` at `2026-06-06T15:40:30.187982531Z[UTC]`
PR: https://github.com/jenkinsci/byte-buddy-api-plugin/pull/130