### PR TITLE
Modernization-metadata for commons-math3-api

### DIFF
--- a/commons-math3-api/modernization-metadata/2026-06-06T15-41-52.json
+++ b/commons-math3-api/modernization-metadata/2026-06-06T15-41-52.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "commons-math3-api",
+  "pluginRepository": "https://github.com/jenkinsci/commons-math3-api-plugin.git",
+  "pluginVersion": "3.6.1-104.vc3227d955289",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/59",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T15-41-52.json",
+  "path": "metadata-plugin-modernizer/commons-math3-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `commons-math3-api` at `2026-06-06T15:41:56.821607193Z[UTC]`
PR: https://github.com/jenkinsci/commons-math3-api-plugin/pull/59