### PR TITLE
Modernization-metadata for gitlab-kubernetes-credentials

### DIFF
--- a/gitlab-kubernetes-credentials/modernization-metadata/2026-06-06T16-03-52.json
+++ b/gitlab-kubernetes-credentials/modernization-metadata/2026-06-06T16-03-52.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "gitlab-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin.git",
+  "pluginVersion": "538.v99cc6503c421",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2026-06-06T16-03-52.json",
+  "path": "metadata-plugin-modernizer/gitlab-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gitlab-kubernetes-credentials` at `2026-06-06T16:03:55.349772634Z[UTC]`
PR: null