### PR TITLE
Modernization-metadata for jobcacher-oras-storage

### DIFF
--- a/jobcacher-oras-storage/modernization-metadata/2026-06-06T16-20-08.json
+++ b/jobcacher-oras-storage/modernization-metadata/2026-06-06T16-20-08.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jobcacher-oras-storage",
+  "pluginRepository": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin.git",
+  "pluginVersion": "144.vb_727c9b_7d229",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/89",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-20-08.json",
+  "path": "metadata-plugin-modernizer/jobcacher-oras-storage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jobcacher-oras-storage` at `2026-06-06T16:20:12.035465135Z[UTC]`
PR: https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/89