### PR TITLE
Modernization-metadata for joda-time-api

### DIFF
--- a/joda-time-api/modernization-metadata/2026-06-06T16-23-48.json
+++ b/joda-time-api/modernization-metadata/2026-06-06T16-23-48.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "joda-time-api",
+  "pluginRepository": "https://github.com/jenkinsci/joda-time-api-plugin.git",
+  "pluginVersion": "2.14.2-193.v422b_efce56e0",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2026-06-06T16-23-48.json",
+  "path": "metadata-plugin-modernizer/joda-time-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `joda-time-api` at `2026-06-06T16:23:51.095429429Z[UTC]`
PR: null