### PR TITLE
Modernization-metadata for jnr-posix-api

### DIFF
--- a/jnr-posix-api/modernization-metadata/2026-06-06T16-28-34.json
+++ b/jnr-posix-api/modernization-metadata/2026-06-06T16-28-34.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jnr-posix-api",
+  "pluginRepository": "https://github.com/jenkinsci/jnr-posix-api-plugin.git",
+  "pluginVersion": "3.1.22-204.v925e2b_09a_42c",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/151",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-28-34.json",
+  "path": "metadata-plugin-modernizer/jnr-posix-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jnr-posix-api` at `2026-06-06T16:28:39.127579112Z[UTC]`
PR: https://github.com/jenkinsci/jnr-posix-api-plugin/pull/151