### PR TITLE
Modernization-metadata for locale

### DIFF
--- a/locale/modernization-metadata/2026-06-06T16-32-00.json
+++ b/locale/modernization-metadata/2026-06-06T16-32-00.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "locale",
+  "pluginRepository": "https://github.com/jenkinsci/locale-plugin.git",
+  "pluginVersion": "641.v84f22d75fd8b_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/locale-plugin/pull/376",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-32-00.json",
+  "path": "metadata-plugin-modernizer/locale/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `locale` at `2026-06-06T16:32:03.696397437Z[UTC]`
PR: https://github.com/jenkinsci/locale-plugin/pull/376