### PR TITLE
Modernization-metadata for mariadb-api

### DIFF
--- a/mariadb-api/modernization-metadata/2026-06-06T16-35-08.json
+++ b/mariadb-api/modernization-metadata/2026-06-06T16-35-08.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "mariadb-api",
+  "pluginRepository": "https://github.com/jenkinsci/mariadb-api-plugin.git",
+  "pluginVersion": "3.5.8-192.v334b_a_162947e",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/mariadb-api-plugin/pull/104",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-35-08.json",
+  "path": "metadata-plugin-modernizer/mariadb-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `mariadb-api` at `2026-06-06T16:35:11.441338134Z[UTC]`
PR: https://github.com/jenkinsci/mariadb-api-plugin/pull/104