### PR TITLE
Modernization-metadata for openshift-k8s-credentials

### DIFF
--- a/openshift-k8s-credentials/modernization-metadata/2026-06-06T16-41-43.json
+++ b/openshift-k8s-credentials/modernization-metadata/2026-06-06T16-41-43.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "openshift-k8s-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin.git",
+  "pluginVersion": "324.v23475795707d",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/334",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-41-43.json",
+  "path": "metadata-plugin-modernizer/openshift-k8s-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `openshift-k8s-credentials` at `2026-06-06T16:41:46.764664654Z[UTC]`
PR: https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/334