### PR TITLE
Modernization-metadata for oss-symbols-api

### DIFF
--- a/oss-symbols-api/modernization-metadata/2026-06-06T16-44-59.json
+++ b/oss-symbols-api/modernization-metadata/2026-06-06T16-44-59.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "oss-symbols-api",
+  "pluginRepository": "https://github.com/jenkinsci/oss-symbols-api-plugin.git",
+  "pluginVersion": "456.v46e634a_63b_99",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/258",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-44-59.json",
+  "path": "metadata-plugin-modernizer/oss-symbols-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `oss-symbols-api` at `2026-06-06T16:45:02.148880878Z[UTC]`
PR: https://github.com/jenkinsci/oss-symbols-api-plugin/pull/258