### PR TITLE
Modernization-metadata for pipeline-lib-oras

### DIFF
--- a/pipeline-lib-oras/modernization-metadata/2026-06-06T16-53-22.json
+++ b/pipeline-lib-oras/modernization-metadata/2026-06-06T16-53-22.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "pipeline-lib-oras",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-lib-oras-plugin.git",
+  "pluginVersion": "90.vecb_55543088a_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/61",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T16-53-22.json",
+  "path": "metadata-plugin-modernizer/pipeline-lib-oras/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-lib-oras` at `2026-06-06T16:53:25.647934369Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/61