### PR TITLE
Modernization-metadata for simple-priority-sorter

### DIFF
--- a/simple-priority-sorter/modernization-metadata/2026-06-06T17-06-38.json
+++ b/simple-priority-sorter/modernization-metadata/2026-06-06T17-06-38.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "simple-priority-sorter",
+  "pluginRepository": "https://github.com/jenkinsci/simple-priority-sorter-plugin.git",
+  "pluginVersion": "47.v920b_a_09b_0e77",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`",
+  "migrationDescription": "Ensure the pom.xml contains the property `banObsoleteDependencyOverrides.skip` set to `false`.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.BanObsoleteDependencyOverrides",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/simple-priority-sorter-plugin/pull/38",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2026-06-06T17-06-38.json",
+  "path": "metadata-plugin-modernizer/simple-priority-sorter/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `simple-priority-sorter` at `2026-06-06T17:06:42.413740565Z[UTC]`
PR: https://github.com/jenkinsci/simple-priority-sorter-plugin/pull/38