### PR TITLE
Modernization-metadata for bitbucket-kubernetes-credentials

### DIFF
--- a/bitbucket-kubernetes-credentials/modernization-metadata/2026-06-28T14-25-40.json
+++ b/bitbucket-kubernetes-credentials/modernization-metadata/2026-06-28T14-25-40.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "bitbucket-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin.git",
+  "pluginVersion": "662.v96d8b_a_90e07e",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "fail",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2026-06-28T14-25-40.json",
+  "path": "metadata-plugin-modernizer/bitbucket-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-kubernetes-credentials` at `2026-06-28T14:25:43.508681731Z[UTC]`
PR: null