### PR TITLE
Modernization-metadata for database-mariadb

### DIFF
--- a/database-mariadb/modernization-metadata/2026-06-28T14-32-02.json
+++ b/database-mariadb/modernization-metadata/2026-06-28T14-32-02.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "database-mariadb",
+  "pluginRepository": "https://github.com/jenkinsci/database-mariadb-plugin.git",
+  "pluginVersion": "182.v8f1d21b_7c825",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/database-mariadb-plugin/pull/124",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T14-32-02.json",
+  "path": "metadata-plugin-modernizer/database-mariadb/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `database-mariadb` at `2026-06-28T14:32:05.971946115Z[UTC]`
PR: https://github.com/jenkinsci/database-mariadb-plugin/pull/124