### PR TITLE
Modernization-metadata for exclusive-label-plugin

### DIFF
--- a/exclusive-label-plugin/modernization-metadata/2026-06-28T14-33-55.json
+++ b/exclusive-label-plugin/modernization-metadata/2026-06-28T14-33-55.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "exclusive-label-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/exclusive-labels-plugin.git",
+  "pluginVersion": "19.v40532946d413",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/exclusive-labels-plugin/pull/28",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T14-33-55.json",
+  "path": "metadata-plugin-modernizer/exclusive-label-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `exclusive-label-plugin` at `2026-06-28T14:33:59.636312671Z[UTC]`
PR: https://github.com/jenkinsci/exclusive-labels-plugin/pull/28