### PR TITLE
Modernization-metadata for extra-tool-installers

### DIFF
--- a/extra-tool-installers/modernization-metadata/2026-06-28T14-38-05.json
+++ b/extra-tool-installers/modernization-metadata/2026-06-28T14-38-05.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "extra-tool-installers",
+  "pluginRepository": "https://github.com/jenkinsci/extra-tool-installers-plugin.git",
+  "pluginVersion": "234.v67a_eca_496b_8b_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/202",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T14-38-05.json",
+  "path": "metadata-plugin-modernizer/extra-tool-installers/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `extra-tool-installers` at `2026-06-28T14:38:09.037997506Z[UTC]`
PR: https://github.com/jenkinsci/extra-tool-installers-plugin/pull/202