### PR TITLE
Modernization-metadata for extended-read-permission

### DIFF
--- a/extended-read-permission/modernization-metadata/2026-06-28T14-39-42.json
+++ b/extended-read-permission/modernization-metadata/2026-06-28T14-39-42.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "extended-read-permission",
+  "pluginRepository": "https://github.com/jenkinsci/extended-read-permission-plugin.git",
+  "pluginVersion": "68.vd270568a_7520",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/extended-read-permission-plugin/pull/61",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T14-39-42.json",
+  "path": "metadata-plugin-modernizer/extended-read-permission/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `extended-read-permission` at `2026-06-28T14:39:45.544744753Z[UTC]`
PR: https://github.com/jenkinsci/extended-read-permission-plugin/pull/61