### PR TITLE
Modernization-metadata for gitlab-kubernetes-credentials

### DIFF
--- a/gitlab-kubernetes-credentials/modernization-metadata/2026-06-28T14-48-06.json
+++ b/gitlab-kubernetes-credentials/modernization-metadata/2026-06-28T14-48-06.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "gitlab-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin.git",
+  "pluginVersion": "538.v99cc6503c421",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/313",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T14-48-06.json",
+  "path": "metadata-plugin-modernizer/gitlab-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gitlab-kubernetes-credentials` at `2026-06-28T14:48:10.067470493Z[UTC]`
PR: https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/313