### PR TITLE
Modernization-metadata for oras-parameters

### DIFF
--- a/oras-parameters/modernization-metadata/2026-06-28T15-04-49.json
+++ b/oras-parameters/modernization-metadata/2026-06-28T15-04-49.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "oras-parameters",
+  "pluginRepository": "https://github.com/jenkinsci/oras-parameters-plugin.git",
+  "pluginVersion": "27.ve7df57fb_154d",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/oras-parameters-plugin/pull/24",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-04-49.json",
+  "path": "metadata-plugin-modernizer/oras-parameters/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `oras-parameters` at `2026-06-28T15:04:53.144449875Z[UTC]`
PR: https://github.com/jenkinsci/oras-parameters-plugin/pull/24