### PR TITLE
Modernization-metadata for locale

### DIFF
--- a/locale/modernization-metadata/2026-06-28T15-06-59.json
+++ b/locale/modernization-metadata/2026-06-28T15-06-59.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "locale",
+  "pluginRepository": "https://github.com/jenkinsci/locale-plugin.git",
+  "pluginVersion": "641.v84f22d75fd8b_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/locale-plugin/pull/377",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-06-59.json",
+  "path": "metadata-plugin-modernizer/locale/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `locale` at `2026-06-28T15:07:03.229489665Z[UTC]`
PR: https://github.com/jenkinsci/locale-plugin/pull/377