### PR TITLE
Modernization-metadata for pipeline-cps-http

### DIFF
--- a/pipeline-cps-http/modernization-metadata/2026-06-28T15-20-45.json
+++ b/pipeline-cps-http/modernization-metadata/2026-06-28T15-20-45.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "pipeline-cps-http",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-cps-http-plugin.git",
+  "pluginVersion": "201.v59370c7cf0ec",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/92",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-20-45.json",
+  "path": "metadata-plugin-modernizer/pipeline-cps-http/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-cps-http` at `2026-06-28T15:20:48.985548341Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/92