### PR TITLE
Modernization-metadata for pipeline-lib-oras

### DIFF
--- a/pipeline-lib-oras/modernization-metadata/2026-06-28T15-24-49.json
+++ b/pipeline-lib-oras/modernization-metadata/2026-06-28T15-24-49.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "pipeline-lib-oras",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-lib-oras-plugin.git",
+  "pluginVersion": "90.vecb_55543088a_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/64",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-24-49.json",
+  "path": "metadata-plugin-modernizer/pipeline-lib-oras/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-lib-oras` at `2026-06-28T15:24:52.901618237Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/64