### PR TITLE
Modernization-metadata for pipeline-cps-oras

### DIFF
--- a/pipeline-cps-oras/modernization-metadata/2026-06-28T15-26-59.json
+++ b/pipeline-cps-oras/modernization-metadata/2026-06-28T15-26-59.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "pipeline-cps-oras",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-cps-oras-plugin.git",
+  "pluginVersion": "88.v0d7eff910a_13",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/66",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-26-59.json",
+  "path": "metadata-plugin-modernizer/pipeline-cps-oras/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-cps-oras` at `2026-06-28T15:27:03.157414139Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/66