### PR TITLE
Modernization-metadata for s3-jobcacher-storage

### DIFF
--- a/s3-jobcacher-storage/modernization-metadata/2026-06-28T15-31-46.json
+++ b/s3-jobcacher-storage/modernization-metadata/2026-06-28T15-31-46.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "s3-jobcacher-storage",
+  "pluginRepository": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin.git",
+  "pluginVersion": "62.v260cb_8db_5b_fa_",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/75",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-31-46.json",
+  "path": "metadata-plugin-modernizer/s3-jobcacher-storage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `s3-jobcacher-storage` at `2026-06-28T15:31:49.773358290Z[UTC]`
PR: https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/75