### PR TITLE
Modernization-metadata for skip-notifications-trait

### DIFF
--- a/skip-notifications-trait/modernization-metadata/2026-06-28T15-35-34.json
+++ b/skip-notifications-trait/modernization-metadata/2026-06-28T15-35-34.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "skip-notifications-trait",
+  "pluginRepository": "https://github.com/jenkinsci/skip-notifications-trait-plugin.git",
+  "pluginVersion": "625.vb_f5e11e9b_158",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/324",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-35-34.json",
+  "path": "metadata-plugin-modernizer/skip-notifications-trait/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `skip-notifications-trait` at `2026-06-28T15:35:38.330203861Z[UTC]`
PR: https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/324