### PR TITLE
Modernization-metadata for simple-priority-sorter

### DIFF
--- a/simple-priority-sorter/modernization-metadata/2026-06-28T15-37-29.json
+++ b/simple-priority-sorter/modernization-metadata/2026-06-28T15-37-29.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "simple-priority-sorter",
+  "pluginRepository": "https://github.com/jenkinsci/simple-priority-sorter-plugin.git",
+  "pluginVersion": "47.v920b_a_09b_0e77",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/simple-priority-sorter-plugin/pull/39",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-37-29.json",
+  "path": "metadata-plugin-modernizer/simple-priority-sorter/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `simple-priority-sorter` at `2026-06-28T15:37:33.149451901Z[UTC]`
PR: https://github.com/jenkinsci/simple-priority-sorter-plugin/pull/39