### PR TITLE
Modernization-metadata for webhook-secret-credentials-provider

### DIFF
--- a/webhook-secret-credentials-provider/modernization-metadata/2026-06-28T15-39-43.json
+++ b/webhook-secret-credentials-provider/modernization-metadata/2026-06-28T15-39-43.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "webhook-secret-credentials-provider",
+  "pluginRepository": "https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin.git",
+  "pluginVersion": "16.v0cfa_f0215cf5",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.541",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin/pull/25",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2026-06-28T15-39-43.json",
+  "path": "metadata-plugin-modernizer/webhook-secret-credentials-provider/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `webhook-secret-credentials-provider` at `2026-06-28T15:39:46.855895922Z[UTC]`
PR: https://github.com/jenkinsci/webhook-secret-credentials-provider-plugin/pull/25