### PR TITLE
Modernization-metadata for gitlab-kubernetes-credentials

### DIFF
--- a/gitlab-kubernetes-credentials/modernization-metadata/2026-06-28T16-05-10.json
+++ b/gitlab-kubernetes-credentials/modernization-metadata/2026-06-28T16-05-10.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "gitlab-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin.git",
+  "pluginVersion": "538.v99cc6503c421",
+  "jenkinsBaseline": "2.528",
+  "targetBaseline": "2.528",
+  "effectiveBaseline": "2.528",
+  "jenkinsVersion": "2.528.3",
+  "migrationName": "Remove Release Drafter if CD is enabled",
+  "migrationDescription": "Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter",
+  "migrationStatus": "success",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2026-06-28T16-05-10.json",
+  "path": "metadata-plugin-modernizer/gitlab-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gitlab-kubernetes-credentials` at `2026-06-28T16:05:13.639345580Z[UTC]`
PR: null